### PR TITLE
Add a setting to display battery information

### DIFF
--- a/launcher/src/main/java/org/cosinus/launchertv/Setup.java
+++ b/launcher/src/main/java/org/cosinus/launchertv/Setup.java
@@ -104,6 +104,15 @@ public class Setup {
 		return (true);
 	}
 
+	public boolean showBattery() {
+		try {
+			return (getPreferences().getBoolean(Preferences.PREFERENCE_SHOW_BATTERY, false));
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+		return (false);
+	}
+
 	public boolean showNames() {
 		try {
 			return (getPreferences().getBoolean(Preferences.PREFERENCE_SHOW_NAME, true));

--- a/launcher/src/main/java/org/cosinus/launchertv/activities/Preferences.java
+++ b/launcher/src/main/java/org/cosinus/launchertv/activities/Preferences.java
@@ -39,6 +39,7 @@ public class Preferences extends PreferenceActivity {
 	public static final String PREFERENCE_TRANSPARENCY = "preference_transparency";
 	public static final String PREFERENCE_SCREEN_ON = "preference_screen_always_on";
 	public static final String PREFERENCE_SHOW_DATE = "preference_show_date";
+	public static final String PREFERENCE_SHOW_BATTERY = "preference_show_battery";
 	public static final String PREFERENCE_GRID_X = "preference_grid_x";
 	public static final String PREFERENCE_GRID_Y = "preference_grid_y";
 	public static final String PREFERENCE_SHOW_NAME = "preference_show_name";

--- a/launcher/src/main/res/layout/fragment_application.xml
+++ b/launcher/src/main/res/layout/fragment_application.xml
@@ -39,11 +39,55 @@
 			android:src="@drawable/ic_apps"
 			tools:ignore="ContentDescription"/>
 
+		<LinearLayout
+			android:id="@+id/battery_layout"
+			android:visibility="invisible"
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:layout_gravity="right"
+			android:layout_weight="1"
+			android:orientation="vertical"
+			android:paddingStart="5dp"
+			android:paddingEnd="5dp"
+			android:paddingLeft="5dp"
+			android:paddingRight="5dp">
+
+			<LinearLayout
+				android:layout_width="match_parent"
+				android:layout_height="match_parent"
+				android:orientation="horizontal"
+				android:gravity="right">
+				<TextView
+					android:id="@+id/battery_level"
+					android:layout_width="wrap_content"
+					android:layout_height="wrap_content"
+					android:maxLines="1"
+					android:shadowColor="#ff000000"
+					android:shadowDx="1"
+					android:shadowDy="1"
+					android:shadowRadius="0.5"
+					android:text="@string/test_battery"
+					android:textColor="#ffffffff"
+					android:textSize="25sp"/>
+
+				<ImageView
+					android:id="@+id/battery_icon"
+					android:layout_width="wrap_content"
+					android:layout_height="match_parent"
+					android:paddingEnd="5dp"
+					android:paddingLeft="5dp"
+					android:paddingRight="5dp"
+					android:layout_marginTop="5dp"/>
+
+			</LinearLayout>
+		</LinearLayout>
+
 
 		<LinearLayout
-			android:layout_width="0dp"
+			android:layout_width="wrap_content"
 			android:layout_height="wrap_content"
-			android:layout_weight="1"
+			android:layout_gravity="right"
+			android:layout_weight="0"
 			android:orientation="vertical"
 			android:paddingStart="5dp"
 			android:paddingEnd="5dp"

--- a/launcher/src/main/res/values-cs/strings.xml
+++ b/launcher/src/main/res/values-cs/strings.xml
@@ -47,4 +47,6 @@
 	<string name="home_locked">Icon is locked by settings</string>
 	<string name="summary_locked">Prevent icons to be accidentally removed</string>
 	<string name="title_locked">Lock icons</string>
+	<string name="title_show_battery_information">Zobrazit informace o baterii</string>
+	<string name="summary_show_battery_information">Zobrazit stav baterie a stav na domovské obrazovce</string>
 </resources>

--- a/launcher/src/main/res/values-fr/strings.xml
+++ b/launcher/src/main/res/values-fr/strings.xml
@@ -44,4 +44,6 @@
 	<string name="home_locked">Icone verrouillée (cf. Préférences)</string>
 	<string name="summary_locked">Empêcher  la suppression accidentelle des icones</string>
 	<string name="title_locked">Verrouiller les icones</string>
+	<string name="title_show_battery_information">Afficher les informations sur la batterie</string>
+	<string name="summary_show_battery_information">Afficher le niveau et l\'état de la batterie sur l\'écran d\'accueil</string>
 </resources>

--- a/launcher/src/main/res/values-sk/strings.xml
+++ b/launcher/src/main/res/values-sk/strings.xml
@@ -46,4 +46,6 @@
 	<string name="home_locked">Icon is locked by settings</string>
 	<string name="summary_locked">Prevent icons to be accidentally removed</string>
 	<string name="title_locked">Lock icons</string>
+	<string name="title_show_battery_information">Zobraziť informácie o batérii</string>
+	<string name="summary_show_battery_information">Zobraziť stav batérie a stav na domovskej obrazovke</string>
 </resources>

--- a/launcher/src/main/res/values/notrans.xml
+++ b/launcher/src/main/res/values/notrans.xml
@@ -19,6 +19,7 @@
 	<string name="app_name" translatable="false">Simple TV Launcher</string>
 	<string name="title_google_plus" translatable="false">Google+</string>
 	<string name="test_clock" translatable="false">00:00</string>
+	<string name="test_battery" translatable="false">42%</string>
 	<string name="test_date" translatable="false">Sunday 1, January</string>
 	<string name="test_application" translatable="false">Application</string>
 	<string name="transparency_default" translatable="false">0.4</string>

--- a/launcher/src/main/res/values/strings.xml
+++ b/launcher/src/main/res/values/strings.xml
@@ -29,7 +29,10 @@
 	<string name="title_system">System settings</string>
 	<string name="summary_system">Open system settings</string>
 	<string name="summary_show_date">Display the date bellow time</string>
+	<string name="summary_show_battery_information">Display battery level and status in home screen</string>
 	<string name="title_show_date">Display date</string>
+	<string name="title_show_battery_information">Display battery information</string>
+	<string name="battery_level_text" translatable="false">%1d%%</string>
 	<string name="summary_show_name">Display applications names on main screen</string>
 	<string name="title_show_name">Display names</string>
 	<string name="title_margin_x">Icons margins X</string>

--- a/launcher/src/main/res/xml/preferences.xml
+++ b/launcher/src/main/res/xml/preferences.xml
@@ -28,6 +28,11 @@
 			android:summary="@string/summary_show_date"
 			android:title="@string/title_show_date"/>
 		<CheckBoxPreference
+			android:defaultValue="false"
+			android:key="preference_show_battery"
+			android:summary="@string/summary_show_battery_information"
+			android:title="@string/title_show_battery_information"/>
+		<CheckBoxPreference
 			android:defaultValue="true"
 			android:key="preference_show_name"
 			android:summary="@string/summary_show_name"


### PR DESCRIPTION
Thanks for sharing this launcher, it's my preferred choice for Android TV boxes.

This year [O Apalpador ](https://en.wikipedia.org/wiki/List_of_Christmas_and_winter_gift-bringers_by_country) was kind enough to get me a Retroid Pocket 2; the thing is something like a portable console, without a touchscreen, and running Android, so I installed this launcher on it to make it easier to use with the d-pad.

It's working like a charm, but I'm missing some battery information in the home screen, so I made this little patch:

- This is disabled by default, so this doesn't show `0% ?` on devices without a battery
- I use whatever `BatteryManager` thinks is the right icon for the current battery status. I find that icon pretty ugly in every device I tested this on, so in the future I may add a custom drawable to use as battery status icon.
- No idea if the translations are right, I just used google translate here.
- Tested on said Retroid thing and in an Android TV emulator at 720p.

Hope you find this patch useful. Happy holidays!